### PR TITLE
Fix battle error when winning with no pokemon sent out

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/pickup/CobblemonPickup.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/pickup/CobblemonPickup.kt
@@ -21,8 +21,8 @@ class CobblemonPickup : ModInitializer {
 
     override fun onInitialize() {
         CobblemonEvents.BATTLE_VICTORY.subscribe { evt ->
-            val world = evt.winners.firstNotNullOf { winner -> winner.pokemonList.firstNotNullOf { battlePokemon -> battlePokemon.entity?.world } }
-            if (world.server == null) return@subscribe
+            val world = evt.winners.flatMap { it.pokemonList }.firstNotNullOfOrNull { it.entity?.world }
+            if (world?.server == null) return@subscribe
             for (winner in evt.winners) {
                 val position = winner.pokemonList.firstNotNullOf { it.entity }.blockPos
                 for (battlePokemon in winner.pokemonList) {


### PR DESCRIPTION
It's possible to battle without your pokemon sent out, so firstNotNullOf entity?.world throws an exception.
Not sure what you want the behavior to be when the winner has no pokemon sent out, I just made it cancel the pickup.